### PR TITLE
Release 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - "7.2"
+  - "7.1"
+  - "7.0"
+  - "5.6"
+
+install:
+  - composer install
+
+script: 
+  - vendor/bin/phpunit
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Jwt-Wrapper for Firebase Jwt
 
+[![Opensource ByJG](https://img.shields.io/badge/opensource-byjg.com-brightgreen.svg)](http://opensource.byjg.com)
 [![Build Status](https://travis-ci.org/byjg/jwt-wrapper.svg?branch=master)](https://travis-ci.org/byjg/jwt-wrapper)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/byjg/jwt-wrapper/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/byjg/jwt-wrapper/?branch=master)
 
@@ -159,4 +160,7 @@ Access from you web browser the client.html
 ```
 http://localhost:8080/client.html
 ```
+
+----
+[Open source ByJG](http://opensource.byjg.com)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 ```php
 <?php
 $server = "example.com";
-$secret = base64_encode("secrect_key_for_test");
+$secret = new \ByJG\Util\JwtKeySecret(base64_encode("secrect_key_for_test"));
 
 $jwtWrapper = new \ByJG\Util\JwtWrapper($server, $secret);
 
@@ -122,7 +122,8 @@ TEXT;
 
 # Note that if you want to use RSA just pass the 3rd argument (public key)
 # See above how to create the RSA Key pair.
-$jwtWrapper = new \ByJG\Util\JwtWrapper($server, $secret, $public);
+$jwtKey = new \ByJG\Util\JwtRsaKey($secret, $public);
+$jwtWrapper = new \ByJG\Util\JwtWrapper($server, $jwtKey);
 
 $token = $jwtWrapper->createJwtData([
     "key" => "value",

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $token = $jwtWrapper->createJwtData([
 
 ```php
 <?php
-# If exists $_SERVER['HTTP_AUTHENTICATION']
+# If exists $_SERVER['HTTP_AUTHENTICATION'] = "Bearer $TOKEN"
 $data = $jwtWrapper->extractData();
 
 # If you want decode directly:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Jwt-Wrapper for Firebase Jwt
+
+[![Build Status](https://travis-ci.org/byjg/jwt-wrapper.svg?branch=master)](https://travis-ci.org/byjg/jwt-wrapper)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/byjg/jwt-wrapper/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/byjg/jwt-wrapper/?branch=master)
 
 A very simple wrapper for create, encode, decode JWT Tokens and abstract the PHP JWT Component

--- a/README.md
+++ b/README.md
@@ -40,20 +40,105 @@ Resource
 
 # Create your Jwt Secret Key
 
-## Good
+You can use two type of secret keys. A Hash (HS512) that is faster, or a RSA (RS512) that is more secure. 
+
+## Hash Key
 
 ```
-openssl rand -base64 32
+openssl rand -base64 64     # set here the size of your key
 ```
 
-## Harder
+## RSA
 
 ```
-openssl rand -base64 64
+ssh-keygen -t rsa -C "Jwt RSA Key" -b 2048 -f private.pem
+openssl rsa -in private.pem -outform PEM -pubout -out public.pem
 ```
 
-**Note**: Do not forget do run base64_decode before pass to JwtWrapper
+**Note**: Save without password 
 
+# Create JWT Token (Hash Encoding):
+
+```php
+<?php
+$server = "example.com";
+$secret = base64_encode("secrect_key_for_test");
+
+$jwtWrapper = new \ByJG\Util\JwtWrapper($server, $secret);
+
+$token = $jwtWrapper->createJwtData([
+    "key" => "value",
+    "key2" => "value2"
+]);
+```
+
+# Create JWT Token (RSA Encoding):
+
+```php
+<?php
+$server = "example.com";
+$secret = <<<TEXT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA5PMdWRa+rUJmg6QMNAPIXa+BJVN7W0vxPN3WTK/OIv5gxgmj
+2inHGGc6f90TW/to948LnqGtcD3CD9KsI55MubafwBYjcds1o9opZ0vYwwdIV80c
+OVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNxcRK38tOCApjZySx/NzMDeaXuWe+1
+nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIklNnyq4TfAUSwl+KN/zjj3CXad1oDT
+7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLnJW1WcLlAAIaAfABtSZboznsStMnY
+to01wVknXKyERFs7FLHYqKQANIvRhFTptsehowIDAQABAoIBAEkJkaQ5EE0fcKqw
+K8BwMHxKn81zi1e9q1C6iEHgl8csFV03+BCB4WTUkaH2udVPJ9ZJyPArLbQvz3fS
+wl1+g4V/UAksRtRslPkXgLvWQ2k8KoTwBv/3nn9Kkozk/h8chHuii0BDs30yzSn4
+SdDAc9EZopsRhFklv9xgmJjYalRk02OLck73G+d6MpDqX56o2UA/lf6i9MV19KWP
+HYip7CAN+i6k8gA0KPHwr76ehgQ6YHtSntkWS8RfVI8fLUB1UlT3HmLgUBNXMWkQ
+ZZbvXtNOt6NtW/WIAHEYeE9jmFgrpW5jKJSLn5iGVPFZwJIZXRPyELEs9NHWkS6e
+GmdzxnECgYEA8+m05B/tmeZOuMrPVJV9g+aBDcuxmW+sdLRch+ccSmx4ZNQOLVoU
+klYgTZq/a1O4ENq0h2WgccNlRHdcH4sXMBvLalA/tFhZMUuA/KXWyZ1F0hBnjHVF
+cj1alHCqh+9qJDGdn4mxSmrp8p0rfeWgBwlFtJEJmjjDWDCtVY+JZcsCgYEA8EuV
+WF/ilgDjgC4jMCYNuO0oFGBbtNP17PuU3kh8W+joqK/nufZ3NLy1WrDIpqa9YPex
+328Nnjljf5GJWSdMchAp82waLzl7FaaBTY0iyFAK4J0jfC/fVLx82+wpM3utDnh8
+9x5iIboO5U7uEJ7k8X2p64GoprlKJSRmGAJ7eIkCgYEAw5IsXI3NMY0cqcbUHvoO
+PehgqfMdX+3O1XSYjM+eO35lulLdWzfTLtKn7BGcUi46dCkofzfZQd5uIEukLhaU
+bRqcK45UxgHg4kmsDufaJKZaCWjl3hVZrZPMQSFlWsF41bSCshzxbr3y/3lOGhA4
+E+w3W+S/Uk0ZNGkzUltYy6kCgYEA0gRNeBr9z7rhG4O3j3qC3dCxCfYZ0Na8hy5v
+M0PJJQ9QYTa04iyOjVItcyE1jaoHtLtoA+9syJBB7RoHIBufzcVg1Pbzf7jOYeLP
++jbTYp3Kk/vjKsQwfj/rJM+oRu3eF9qo5dbxT6btI++zVGV7lbEOFN6Sx30EV6gT
+bwKkZXkCgYEAnEtN43xL8bRFybMc1ZJErjc0VocnoQxCHm7LuAtLOEUw6CwwFj9Q
+GOl+GViVuDHUNQvURLn+6gg4tAemYlob912xIPaU44+lZzTMHBOJBGMJKi8WogKi
+V5+cz9l31uuAgNfjL63jZPaAzKs8Zx6R3O5RuezympwijCIGWILbO2Q=
+-----END RSA PRIVATE KEY-----
+TEXT;
+          
+$public = <<<TEXT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5PMdWRa+rUJmg6QMNAPI
+Xa+BJVN7W0vxPN3WTK/OIv5gxgmj2inHGGc6f90TW/to948LnqGtcD3CD9KsI55M
+ubafwBYjcds1o9opZ0vYwwdIV80cOVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNx
+cRK38tOCApjZySx/NzMDeaXuWe+1nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIkl
+Nnyq4TfAUSwl+KN/zjj3CXad1oDT7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLn
+JW1WcLlAAIaAfABtSZboznsStMnYto01wVknXKyERFs7FLHYqKQANIvRhFTptseh
+owIDAQAB
+-----END PUBLIC KEY-----
+TEXT;
+
+# Note that if you want to use RSA just pass the 3rd argument (public key)
+# See above how to create the RSA Key pair.
+$jwtWrapper = new \ByJG\Util\JwtWrapper($server, $secret, $public);
+
+$token = $jwtWrapper->createJwtData([
+    "key" => "value",
+    "key2" => "value2"
+]);
+```
+
+# Extracting
+
+```php
+<?php
+# If exists $_SERVER['HTTP_AUTHENTICATION']
+$data = $jwtWrapper->extractData();
+
+# If you want decode directly:
+$data = $jwtWrapper->extractData($token);
+```
 
 # Running a sample test
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ $data = $jwtWrapper->extractData();
 $data = $jwtWrapper->extractData($token);
 ```
 
+# Install
+
+```bash
+composer require "byjg/jwt-wrapper=2.0.*"
+```
+
 # Running a sample test
 
 Start a local server:

--- a/_config.yml
+++ b/_config.yml
@@ -41,13 +41,26 @@ social:
     hash: opensourcebyjg
     account: 
   facebook:
-    enabled: false
+    enabled: true
+    url: https://opensource.byjg.com/
     profileUrl:
+
+author:
+  twitter: byjg
+
+twitter:
+  card: summary
+  username: byjg
+
+logo: https://opensource.byjg.com/images/logo_byjg.png
 
 analytics:
   google: UA-130014324-1
 
+plugins:
+  - jekyll-seo-tag
+
 # Build settings
 markdown: kramdown
-remote_theme: allejo/jekyll-docs-theme
+remote_theme: byjg/jekyll-docs-theme
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
   },
   "license": "MIT",
   "require": {
-    "firebase/php-jwt": "^3.0"
+    "firebase/php-jwt": "^3.0",
+    "ext-openssl": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": ">5.7"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "require": {
-    "firebase/php-jwt": "^3.0",
+    "firebase/php-jwt": "^5.0",
     "ext-openssl": "*"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+To change this license header, choose License Headers in Project Properties.
+To change this template file, choose Tools | Templates
+and open the template in the editor.
+-->
+
+<!-- see http://www.phpunit.de/wiki/Documentation -->
+<phpunit bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnFailure="false">
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/src/JwtKeyInterface.php
+++ b/src/JwtKeyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ByJG\Util;
+
+interface JwtKeyInterface
+{
+    public function getPublicKey();
+    public function getPrivateKey();
+    public function getAlghoritm();
+}

--- a/src/JwtKeySecret.php
+++ b/src/JwtKeySecret.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ByJG\Util;
+
+class JwtKeySecret implements JwtKeyInterface
+{
+
+    protected $key;
+
+    /**
+     * JwtKeySecret constructor.
+     * @param $key
+     * @param bool $decode
+     */
+    public function __construct($key, $decode = true)
+    {
+        $this->key = ($decode ? base64_decode($key) : $key);
+    }
+
+    /**
+     * @param $key
+     * @param bool $decode
+     * @return JwtKeySecret
+     */
+    public static function getInstance($key, $decode = true)
+    {
+        return new JwtKeySecret($key, $decode);
+    }
+
+    public function getPublicKey()
+    {
+        return $this->key;
+    }
+
+    public function getPrivateKey()
+    {
+        return $this->key;
+    }
+
+    public function getAlghoritm()
+    {
+        return 'HS512';
+    }
+}

--- a/src/JwtRsaKey.php
+++ b/src/JwtRsaKey.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ByJG\Util;
+
+class JwtRsaKey implements JwtKeyInterface
+{
+    protected $private;
+    protected $public;
+
+    /**
+     * JwtRsaKey constructor.
+     * @param $private
+     * @param $public
+     */
+    public function __construct($private, $public)
+    {
+        $this->private = $private;
+        $this->public = $public;
+    }
+
+    /**
+     * @param $private
+     * @param $public
+     * @return JwtRsaKey
+     */
+    public static function getInstance($private, $public)
+    {
+        return new JwtRsaKey($private, $public);
+    }
+
+    public function getPublicKey()
+    {
+        return $this->public;
+    }
+
+    public function getPrivateKey()
+    {
+        return $this->private;
+    }
+
+    public function getAlghoritm()
+    {
+        return 'RS512';
+    }
+}

--- a/src/JwtWrapper.php
+++ b/src/JwtWrapper.php
@@ -65,17 +65,21 @@ class JwtWrapper
         return $jwt;
     }
 
-    /*
-    * Extract the key, which is coming from the config file.
-    *
-    * Best suggestion is the key to be a binary string and
-    * store it in encoded in a config file.
-    *
-    * Can be generated with base64_encode(openssl_random_pseudo_bytes(64));
-    *
-    * keep it secure! You'll need the exact key to verify the
-    * token later.
-    */
+    /**
+     * Extract the key, which is coming from the config file.
+     *
+     * Best suggestion is the key to be a binary string and
+     * store it in encoded in a config file.
+     *
+     * Can be generated with base64_encode(openssl_random_pseudo_bytes(64));
+     *
+     * keep it secure! You'll need the exact key to verify the
+     * token later.
+     *
+     * @param null $bearer
+     * @return object
+     * @throws JwtWrapperException
+     */
     public function extractData($bearer = null)
     {
         if (empty($bearer)) {
@@ -91,16 +95,24 @@ class JwtWrapper
             ]
         );
 
+        if (isset($jwtData->iss) && $jwtData->iss != $this->serverName) {
+            throw new JwtWrapperException("Issuer does not match");
+        }
+
         return $jwtData;
     }
 
+    /**
+     * @return mixed
+     * @throws JwtWrapperException
+     */
     public function getAuthorizationBearer()
     {
         $authorization = isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] : "";
         list($bearer) = sscanf($authorization, 'Bearer %s');
 
         if (empty($bearer)) {
-            throw new \Exception('Absent authorization token');
+            throw new JwtWrapperException('Absent authorization token');
         }
 
         return $bearer;

--- a/src/JwtWrapperException.php
+++ b/src/JwtWrapperException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ByJG\Util;
+
+class JwtWrapperException extends \Exception
+{
+
+}

--- a/tests/JwtWrapperHashTest.php
+++ b/tests/JwtWrapperHashTest.php
@@ -3,7 +3,7 @@
 use ByJG\Util\JwtWrapper;
 use PHPUnit\Framework\TestCase;
 
-class JwtWrapperTest extends TestCase
+class JwtWrapperHashTest extends TestCase
 {
 
     /**
@@ -13,10 +13,14 @@ class JwtWrapperTest extends TestCase
 
     protected $dataToToken = ["name" => "John", "id"=>"1"];
     protected $server = "example.com";
-    protected $secret = "secrect_key_for_test";
+    protected $secret;
+    protected $public;
 
     protected function setUp()
     {
+        $this->secret = base64_encode("secrect_key_for_test");
+        $this->public = null;
+
         unset($_SERVER["HTTP_AUTHORIZATION"]);
         $this->object = new JwtWrapper($this->server, $this->secret);
     }
@@ -103,7 +107,7 @@ class JwtWrapperTest extends TestCase
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $jwtWrapper = new JwtWrapper("otherserver.com", $this->secret);
+        $jwtWrapper = new JwtWrapper("otherserver.com", $this->secret, $this->public);
 
         $jwtWrapper->extractData($token);
     }
@@ -117,7 +121,7 @@ class JwtWrapperTest extends TestCase
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $jwtWrapper = new JwtWrapper($this->server, "some_creepy_secret");
+        $jwtWrapper = new JwtWrapper($this->server, base64_encode("some_creepy_secret"));
 
         $jwtWrapper->extractData($token);
     }

--- a/tests/JwtWrapperHashTest.php
+++ b/tests/JwtWrapperHashTest.php
@@ -13,16 +13,18 @@ class JwtWrapperHashTest extends TestCase
 
     protected $dataToToken = ["name" => "John", "id"=>"1"];
     protected $server = "example.com";
-    protected $secret;
-    protected $public;
+
+    /**
+     * @var \ByJG\Util\JwtKeyInterface
+     */
+    protected $jwtKey;
 
     protected function setUp()
     {
-        $this->secret = base64_encode("secrect_key_for_test");
-        $this->public = null;
+        $this->jwtKey = \ByJG\Util\JwtKeySecret::getInstance("secrect_key_for_test", false);
 
         unset($_SERVER["HTTP_AUTHORIZATION"]);
-        $this->object = new JwtWrapper($this->server, $this->secret);
+        $this->object = new JwtWrapper($this->server, $this->jwtKey);
     }
 
     protected function tearDown()
@@ -107,7 +109,7 @@ class JwtWrapperHashTest extends TestCase
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $jwtWrapper = new JwtWrapper("otherserver.com", $this->secret, $this->public);
+        $jwtWrapper = new JwtWrapper("otherserver.com", $this->jwtKey);
 
         $jwtWrapper->extractData($token);
     }
@@ -121,7 +123,7 @@ class JwtWrapperHashTest extends TestCase
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $jwtWrapper = new JwtWrapper($this->server, base64_encode("some_creepy_secret"));
+        $jwtWrapper = new JwtWrapper($this->server, new \ByJG\Util\JwtKeySecret("some_creepy_secret", true));
 
         $jwtWrapper->extractData($token);
     }

--- a/tests/JwtWrapperSecretTest.php
+++ b/tests/JwtWrapperSecretTest.php
@@ -6,9 +6,12 @@ require_once __DIR__ . '/JwtWrapperHashTest.php';
 
 class JwtWrapperSecretTest extends JwtWrapperHashTest
 {
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     */
     protected function setUp()
     {
-        $this->secret = <<<TEXT
+        $private = <<<TEXT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEA5PMdWRa+rUJmg6QMNAPIXa+BJVN7W0vxPN3WTK/OIv5gxgmj
 2inHGGc6f90TW/to948LnqGtcD3CD9KsI55MubafwBYjcds1o9opZ0vYwwdIV80c
@@ -37,8 +40,7 @@ GOl+GViVuDHUNQvURLn+6gg4tAemYlob912xIPaU44+lZzTMHBOJBGMJKi8WogKi
 V5+cz9l31uuAgNfjL63jZPaAzKs8Zx6R3O5RuezympwijCIGWILbO2Q=
 -----END RSA PRIVATE KEY-----
 TEXT;
-
-        $this->public = <<<TEXT
+        $public = <<<TEXT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5PMdWRa+rUJmg6QMNAPI
 Xa+BJVN7W0vxPN3WTK/OIv5gxgmj2inHGGc6f90TW/to948LnqGtcD3CD9KsI55M
@@ -49,9 +51,11 @@ JW1WcLlAAIaAfABtSZboznsStMnYto01wVknXKyERFs7FLHYqKQANIvRhFTptseh
 owIDAQAB
 -----END PUBLIC KEY-----
 TEXT;
-;
+
+        $this->jwtKey = new \ByJG\Util\JwtRsaKey($private, $public);
+
         unset($_SERVER["HTTP_AUTHORIZATION"]);
-        $this->object = new JwtWrapper($this->server, $this->secret, $this->public);
+        $this->object = new JwtWrapper($this->server, $this->jwtKey);
     }
 
 
@@ -64,7 +68,7 @@ TEXT;
         $jwt = $this->object->createJwtData($this->dataToToken);
         $token = $this->object->generateToken($jwt);
 
-        $secret = <<<TEXT
+        $private = <<<TEXT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEpgIBAAKCAQEA9QTmRYW+S+9QeylWIz3cAMAjaIsJeO32/2IKYS54BBgd9xYp
 ByUUabiua8YvKwv5lmWv2P/llzUQz5ppU1nkiZljeofkEmxdxKTaLhX5Cd4WZteC
@@ -105,11 +109,8 @@ fQIDAQAB
 -----END PUBLIC KEY-----
 TEXT;
 
-
-        $jwtWrapper = new JwtWrapper($this->server, $secret, $public);
+        $jwtWrapper = new JwtWrapper($this->server, \ByJG\Util\JwtRsaKey::getInstance($private, $public));
 
         $jwtWrapper->extractData($token);
     }
-
-
 }

--- a/tests/JwtWrapperSecretTest.php
+++ b/tests/JwtWrapperSecretTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use ByJG\Util\JwtWrapper;
+
+require_once __DIR__ . '/JwtWrapperHashTest.php';
+
+class JwtWrapperSecretTest extends JwtWrapperHashTest
+{
+    protected function setUp()
+    {
+        $this->secret = <<<TEXT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEA5PMdWRa+rUJmg6QMNAPIXa+BJVN7W0vxPN3WTK/OIv5gxgmj
+2inHGGc6f90TW/to948LnqGtcD3CD9KsI55MubafwBYjcds1o9opZ0vYwwdIV80c
+OVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNxcRK38tOCApjZySx/NzMDeaXuWe+1
+nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIklNnyq4TfAUSwl+KN/zjj3CXad1oDT
+7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLnJW1WcLlAAIaAfABtSZboznsStMnY
+to01wVknXKyERFs7FLHYqKQANIvRhFTptsehowIDAQABAoIBAEkJkaQ5EE0fcKqw
+K8BwMHxKn81zi1e9q1C6iEHgl8csFV03+BCB4WTUkaH2udVPJ9ZJyPArLbQvz3fS
+wl1+g4V/UAksRtRslPkXgLvWQ2k8KoTwBv/3nn9Kkozk/h8chHuii0BDs30yzSn4
+SdDAc9EZopsRhFklv9xgmJjYalRk02OLck73G+d6MpDqX56o2UA/lf6i9MV19KWP
+HYip7CAN+i6k8gA0KPHwr76ehgQ6YHtSntkWS8RfVI8fLUB1UlT3HmLgUBNXMWkQ
+ZZbvXtNOt6NtW/WIAHEYeE9jmFgrpW5jKJSLn5iGVPFZwJIZXRPyELEs9NHWkS6e
+GmdzxnECgYEA8+m05B/tmeZOuMrPVJV9g+aBDcuxmW+sdLRch+ccSmx4ZNQOLVoU
+klYgTZq/a1O4ENq0h2WgccNlRHdcH4sXMBvLalA/tFhZMUuA/KXWyZ1F0hBnjHVF
+cj1alHCqh+9qJDGdn4mxSmrp8p0rfeWgBwlFtJEJmjjDWDCtVY+JZcsCgYEA8EuV
+WF/ilgDjgC4jMCYNuO0oFGBbtNP17PuU3kh8W+joqK/nufZ3NLy1WrDIpqa9YPex
+328Nnjljf5GJWSdMchAp82waLzl7FaaBTY0iyFAK4J0jfC/fVLx82+wpM3utDnh8
+9x5iIboO5U7uEJ7k8X2p64GoprlKJSRmGAJ7eIkCgYEAw5IsXI3NMY0cqcbUHvoO
+PehgqfMdX+3O1XSYjM+eO35lulLdWzfTLtKn7BGcUi46dCkofzfZQd5uIEukLhaU
+bRqcK45UxgHg4kmsDufaJKZaCWjl3hVZrZPMQSFlWsF41bSCshzxbr3y/3lOGhA4
+E+w3W+S/Uk0ZNGkzUltYy6kCgYEA0gRNeBr9z7rhG4O3j3qC3dCxCfYZ0Na8hy5v
+M0PJJQ9QYTa04iyOjVItcyE1jaoHtLtoA+9syJBB7RoHIBufzcVg1Pbzf7jOYeLP
++jbTYp3Kk/vjKsQwfj/rJM+oRu3eF9qo5dbxT6btI++zVGV7lbEOFN6Sx30EV6gT
+bwKkZXkCgYEAnEtN43xL8bRFybMc1ZJErjc0VocnoQxCHm7LuAtLOEUw6CwwFj9Q
+GOl+GViVuDHUNQvURLn+6gg4tAemYlob912xIPaU44+lZzTMHBOJBGMJKi8WogKi
+V5+cz9l31uuAgNfjL63jZPaAzKs8Zx6R3O5RuezympwijCIGWILbO2Q=
+-----END RSA PRIVATE KEY-----
+TEXT;
+
+        $this->public = <<<TEXT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5PMdWRa+rUJmg6QMNAPI
+Xa+BJVN7W0vxPN3WTK/OIv5gxgmj2inHGGc6f90TW/to948LnqGtcD3CD9KsI55M
+ubafwBYjcds1o9opZ0vYwwdIV80cOVZX1IUZFTbnyyKcXeFmKt49A52haCiy4iNx
+cRK38tOCApjZySx/NzMDeaXuWe+1nd3pbgYa/I8MkECa5EyabhZJPJo9fGoSZIkl
+Nnyq4TfAUSwl+KN/zjj3CXad1oDT7XDDgMJDUu/Vxs7h3CQI9zILSYcL9zwttbLn
+JW1WcLlAAIaAfABtSZboznsStMnYto01wVknXKyERFs7FLHYqKQANIvRhFTptseh
+owIDAQAB
+-----END PUBLIC KEY-----
+TEXT;
+;
+        unset($_SERVER["HTTP_AUTHORIZATION"]);
+        $this->object = new JwtWrapper($this->server, $this->secret, $this->public);
+    }
+
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \Firebase\JWT\SignatureInvalidException
+     */
+    public function testTokenWrongSecret()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken);
+        $token = $this->object->generateToken($jwt);
+
+        $secret = <<<TEXT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEA9QTmRYW+S+9QeylWIz3cAMAjaIsJeO32/2IKYS54BBgd9xYp
+ByUUabiua8YvKwv5lmWv2P/llzUQz5ppU1nkiZljeofkEmxdxKTaLhX5Cd4WZteC
+Ef3SfAY3XMoCeNfXFqKt53SAULH2Ao0HzS+tXdru+dES1uD3jcIDMcD+vbQPhDos
+XM96b95Wmi9O5OBbNmZQsBcqv4Ixd8KXokWuNm3Pyo1oa6nCEk08H2wx/26zQ/Jf
+3TsVJ+jYd0UgKsfQxtMU2tMIvJV8bzjS++HHhd/O/oW8go0AAOuSygoPWE0y88dA
+H3bHiWlpRupT8ENCYeMpObpTRXsAFwUn49iofQIDAQABAoIBAQC7vFhP9q0bc6+f
+3slgUVqLvKykwrusS/EQNuerFLbitDPpibJABjpA0z/Z1k1310IS6bE2PMSG+iL6
+Xt7K/bqtb7kYPp0TPLMQJBwEadOaqu9RN1kzPd+UJhMvZp1ESGVGs7k5+jsDGYhc
+5gCPSDO3ETRAd+DOgitME9bsvWqyoI/frI/pFy7Ts4CxoyPgXE1uSZB0D7yPRa3u
+IQ/VX0tBCPx84+81wMdaYGyhVKfa+K/rK9bMvt8xYz/OALRxHLoM157Rmi2HpB90
+2H9N4OnW8NdzdQvAT2PAFYicjEbTszNQ3y8e/WQH+OvpfPW1UpH842D4z2swAfbN
+CU+MLeVlAoGBAPxg6fnKxQpa1oNUgka+MdkJSLTxDUA8YA2Si8hbaVm8TluZJR4x
+CR5c4ElQauSM1X72pqUAdu29wzW67Cy/mXhlCBHm03rnZVVVsmcf/yRLLTHhstmM
+qaXvh08zSb11BUPLp9Alfrsdduzwz4CiKfiaRvFBdphvctzmlVZFszm/AoGBAPiI
+85FMtNi7ImzPbpKaJvjYppW6MdDIPd9rQLh0oWxxAZtodZm8MfmXEqAzWq0Nxq4C
+UyCcp4s6hL1GaTi+R2LcWj0ZxRqYwykRVnptZL9CXzek3lngX5yxOvIV4fHkIIvf
+DKviEQi6kzqLJqRKBiSxp/HmnO+ekF07F1lQ31TDAoGBANxBDBFW+A1oZ2uoFiX9
+GO3L32siMClOR5mwulM6C8Anyc7A4ZbuvoGEFq2FBDTAABbU1WyM8j3bbYD3x+Pp
+tttOePN+mjPZvCL0LkU3tGiNPz0YNwkLbIcHevQQ05sHhHe9RZAvGOHd/gscwksF
+u1Fd+unT8tdn9Dt69PucyqRrAoGBAJfCeIgWwK8+xayPlUMrofR9xmrTASwtuao9
+QY3gmdkvv/13cafoRNPVLehos0vMh68leEEHpz7bAsbYwdOGTOzPBMMegz7UXQcs
+sROczNIE40OFBsj2uythBU9hkVA1LrJ6BrDGIASmeNRct8HF+a5aVOTfHqEqv5hO
+RtmhCl4lAoGBANqI7xQvrP/OWJIZlHahnQbcrcBgsD6IM3kIKdR4s3R08ce20so/
+M1wHFjLKjlHJ6GqeP1y1RV7Ej4kK9vrEz5OYoJlQnjhU2LdREfVdhzuy9tgiW1EW
+mSSFNrpqXwau5wBYZsR7aukXroAMp9ZyUhDjvMP0e4Nh+dajyBBQv5WE
+-----END RSA PRIVATE KEY-----
+TEXT;
+        $public = <<<TEXT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9QTmRYW+S+9QeylWIz3c
+AMAjaIsJeO32/2IKYS54BBgd9xYpByUUabiua8YvKwv5lmWv2P/llzUQz5ppU1nk
+iZljeofkEmxdxKTaLhX5Cd4WZteCEf3SfAY3XMoCeNfXFqKt53SAULH2Ao0HzS+t
+Xdru+dES1uD3jcIDMcD+vbQPhDosXM96b95Wmi9O5OBbNmZQsBcqv4Ixd8KXokWu
+Nm3Pyo1oa6nCEk08H2wx/26zQ/Jf3TsVJ+jYd0UgKsfQxtMU2tMIvJV8bzjS++HH
+hd/O/oW8go0AAOuSygoPWE0y88dAH3bHiWlpRupT8ENCYeMpObpTRXsAFwUn49io
+fQIDAQAB
+-----END PUBLIC KEY-----
+TEXT;
+
+
+        $jwtWrapper = new JwtWrapper($this->server, $secret, $public);
+
+        $jwtWrapper->extractData($token);
+    }
+
+
+}

--- a/tests/JwtWrapperTest.php
+++ b/tests/JwtWrapperTest.php
@@ -124,15 +124,36 @@ class JwtWrapperTest extends TestCase
 
     /**
      * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \Firebase\JWT\ExpiredException
+     */
+    public function testExpiredToken()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken,1);
+        $token = $this->object->generateToken($jwt);
+
+        sleep(2);
+
+        $this->object->extractData($token);
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \Firebase\JWT\BeforeValidException
+     */
+    public function testNotBeforeToken()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken,60, 60);
+        $token = $this->object->generateToken($jwt);
+
+        $this->object->extractData($token);
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
      * @expectedException \ByJG\Util\JwtWrapperException
      */
     public function testGetEmptyAuthorizationBearer()
     {
         $this->object->extractData();
-    }
-
-    public function testGenerateToken()
-    {
-
     }
 }

--- a/tests/JwtWrapperTest.php
+++ b/tests/JwtWrapperTest.php
@@ -156,4 +156,22 @@ class JwtWrapperTest extends TestCase
     {
         $this->object->extractData();
     }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException UnexpectedValueException
+     */
+    public function testGetInvalidTokenSequence()
+    {
+        $this->object->extractData("invalidtoken");
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException DomainException
+     */
+    public function testGetInvalidToken()
+    {
+        $this->object->extractData("invalidtoken.hasthree.parts");
+    }
 }

--- a/tests/JwtWrapperTest.php
+++ b/tests/JwtWrapperTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use ByJG\Util\JwtWrapper;
+use PHPUnit\Framework\TestCase;
+
+class JwtWrapperTest extends TestCase
+{
+
+    /**
+     * @var JwtWrapper
+     */
+    protected $object;
+
+    protected $dataToToken = ["name" => "John", "id"=>"1"];
+    protected $server = "example.com";
+    protected $secret = "secrect_key_for_test";
+
+    protected function setUp()
+    {
+        unset($_SERVER["HTTP_AUTHORIZATION"]);
+        $this->object = new JwtWrapper($this->server, $this->secret);
+    }
+
+    protected function tearDown()
+    {
+        $this->object = null;
+        unset($_SERVER["HTTP_AUTHORIZATION"]);
+    }
+
+
+    public function testSuccessfulFlow1()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken);
+
+        $this->assertEquals([
+            'iat'  => $jwt["iat"],  // Not deterministic for the test
+            'jti'  => $jwt["jti"],  // Not deterministic for the test
+            'iss'  => "example.com",
+            'nbf'  => $jwt["iat"],
+            'exp'  => $jwt["iat"] + 60,
+            'data' => $this->dataToToken
+        ], $jwt);
+
+        $token = $this->object->generateToken($jwt);
+
+        $data = $this->object->extractData($token);
+
+        $expectedData = new stdClass();
+        $expectedData->iat = $jwt["iat"];  // Not deterministic for the test
+        $expectedData->jti = $jwt["jti"];  // Not deterministic for the test
+        $expectedData->iss = "example.com";
+        $expectedData->nbf = $jwt["iat"];
+        $expectedData->exp = $jwt["iat"] + 60;
+        $expectedData->data = (object)$this->dataToToken;
+
+        $this->assertEquals(
+            $expectedData,
+            $data
+        );
+
+    }
+
+    public function testSuccessfulFlow2()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken);
+
+        $this->assertEquals([
+            'iat'  => $jwt["iat"],  // Not deterministic for the test
+            'jti'  => $jwt["jti"],  // Not deterministic for the test
+            'iss'  => "example.com",
+            'nbf'  => $jwt["iat"],
+            'exp'  => $jwt["iat"] + 60,
+            'data' => $this->dataToToken
+        ], $jwt);
+
+        $token = $this->object->generateToken($jwt);
+
+        $_SERVER["HTTP_AUTHORIZATION"] = "Bearer $token";
+
+        $data = $this->object->extractData();
+
+        $expectedData = new stdClass();
+        $expectedData->iat = $jwt["iat"];  // Not deterministic for the test
+        $expectedData->jti = $jwt["jti"];  // Not deterministic for the test
+        $expectedData->iss = "example.com";
+        $expectedData->nbf = $jwt["iat"];
+        $expectedData->exp = $jwt["iat"] + 60;
+        $expectedData->data = (object)$this->dataToToken;
+
+        $this->assertEquals(
+            $expectedData,
+            $data
+        );
+
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \ByJG\Util\JwtWrapperException
+     */
+    public function testTokenWrongServerSameSecret()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken);
+        $token = $this->object->generateToken($jwt);
+
+        $jwtWrapper = new JwtWrapper("otherserver.com", $this->secret);
+
+        $jwtWrapper->extractData($token);
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \Firebase\JWT\SignatureInvalidException
+     */
+    public function testTokenWrongSecret()
+    {
+        $jwt = $this->object->createJwtData($this->dataToToken);
+        $token = $this->object->generateToken($jwt);
+
+        $jwtWrapper = new JwtWrapper($this->server, "some_creepy_secret");
+
+        $jwtWrapper->extractData($token);
+    }
+
+    /**
+     * @throws \ByJG\Util\JwtWrapperException
+     * @expectedException \ByJG\Util\JwtWrapperException
+     */
+    public function testGetEmptyAuthorizationBearer()
+    {
+        $this->object->extractData();
+    }
+
+    public function testGenerateToken()
+    {
+
+    }
+}


### PR DESCRIPTION
Major changes in the JwtWrapper breaking compatibility with old code:

- Added unit tests to perform upgrade of components (Issue #1)
- Upgrade to Firebase Library to 5.0.0
- Added the algorithm RS512.
- Added `JwtKeyInterface` (break compatibility)

**Examples:**

*before*

```php
<?php
$jwt = new JwtWrapper("domain.com", "mykey")
```

*Now*

```php
<?php
$jwt = new JwtWrapper("domain.com", new JwtKeySecret("mykey"))
```
